### PR TITLE
SSO missing token when trying to sign in 

### DIFF
--- a/public/class-award-force-api-v2.php
+++ b/public/class-award-force-api-v2.php
@@ -4,7 +4,7 @@ use GuzzleHttp\Client;
 
 class AwardForceAPIV2 {
 
-    private $apiUrl = 'https://api.staging.awardsplatform.com';
+    private $apiUrl = 'https://api.cr4ce.com';
 
     private $apiKey;
 
@@ -61,7 +61,7 @@ class AwardForceAPIV2 {
         return new Client([
             'base_uri' => $this->apiUrl,
             'headers' => [
-                'Accept' => 'application/vnd.Award Force.v2.0+json',
+                'Accept' => 'application/vnd.Creative Force.v2.0+json',
                 'x-api-key' => $this->apiKey,
             ],
             'http_errors' => false,

--- a/public/class-award-force-api-v2.php
+++ b/public/class-award-force-api-v2.php
@@ -4,7 +4,7 @@ use GuzzleHttp\Client;
 
 class AwardForceAPIV2 {
 
-    private $apiUrl = 'https://api.awardsplatform.com';
+    private $apiUrl = 'https://api.staging.awardsplatform.com';
 
     private $apiKey;
 
@@ -14,7 +14,7 @@ class AwardForceAPIV2 {
     }
 
     /**
-     * Sends a GET request to the Award Force API.
+     * Sends a GET request to the Award Force API.log
      *
      * @param $uri
      * @param array $options

--- a/public/class-award-force-api-v2.php
+++ b/public/class-award-force-api-v2.php
@@ -14,7 +14,7 @@ class AwardForceAPIV2 {
     }
 
     /**
-     * Sends a GET request to the Award Force API.log
+     * Sends a GET request to the Award Force API
      *
      * @param $uri
      * @param array $options

--- a/public/class-award-force-sso.php
+++ b/public/class-award-force-sso.php
@@ -60,10 +60,6 @@ class AwardForceSSO {
     {
         $response = $this->requestSlugByEmail($user->user_email);
 
-        if (isset($response->status_code) && $response->status_code != 200) {
-            $this->api->handleException(new Exception($response->message));
-        }
-
         if (isset($response->slug)) {
             return $response->slug;
         }

--- a/public/class-award-force-sso.php
+++ b/public/class-award-force-sso.php
@@ -64,18 +64,23 @@ class AwardForceSSO {
             return $response->slug;
         }
 
-        $response = $this->api->post('/user', [
+        $response = $this->createUser($user);
+
+        if (!isset($response->slug)) {
+            $this->api->handleException(new Exception($response->message ?: 'There was an error creating the user.'));
+        }
+
+        return $response->slug;
+    }
+
+    private function createUser($user)
+    {
+        return $this->api->post('/user', [
             'email' => $user->user_email,
             'first_name' => $user->user_firstname ?: 'First',
             'last_name' => $user->user_lastname ?: 'Last',
             'password' => uniqid(),
         ]);
-
-        if (isset($response->slug)) {
-            return $response->slug;
-        }
-
-        $this->api->handleException(new Exception($response->message ?: 'There was an error creating the user.'));
     }
 
     private function requestSlugByEmail($email)
@@ -110,7 +115,7 @@ class AwardForceSSO {
         }
 
         if (!$token) {
-            $this->api->handleException(new Exception('There was an error requesting a token to Award Force'));
+            $this->api->handleException(new Exception('There was an error requesting a token from Award Force'));
         }
 
         return $token;

--- a/public/class-award-force-sso.php
+++ b/public/class-award-force-sso.php
@@ -59,11 +59,12 @@ class AwardForceSSO {
     private function requestSlug(WP_User $user)
     {
         $response = $this->requestSlugByEmail($user->user_email);
-        if ($response->status_code != 200) {
+
+        if (isset($response->status_code) && $response->status_code != 200) {
             $this->api->handleException(new Exception($response->message));
         }
 
-        if ($response->slug) {
+        if (isset($response->slug)) {
             return $response->slug;
         }
 
@@ -74,11 +75,11 @@ class AwardForceSSO {
             'password' => uniqid(),
         ]);
 
-        if ($response->status_code != 201) {
-            $this->api->handleException(new Exception($response->message));
+        if (isset($response->slug)) {
+            return $response->slug;
         }
 
-        return $response->slug;
+        $this->api->handleException(new Exception($response->message ?: 'There was an error creating the user.'));
     }
 
     private function requestSlugByEmail($email)
@@ -113,7 +114,7 @@ class AwardForceSSO {
         }
 
         if (!$token) {
-            $this->api->handleException(new Exception('There was an issue requesting a token to Award Force'));
+            $this->api->handleException(new Exception('There was an error requesting a token to Award Force'));
         }
 
         return $token;


### PR DESCRIPTION
<ins>**Problem**</ins>

- When using SSO, users sometimes see the message `The token field is required when token is not present`
- Plugin was relying on the response of the auth token request. If there was an error, it tries to open the domain using an empty token.

<ins>**Solution**</ins>

- Improve the error handling after requesting the auth-token
